### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/geoip-asndata/.AURINFO
+++ b/geoip-asndata/.AURINFO
@@ -6,8 +6,8 @@ pkgbase = geoip-asndata
 	arch = any
 	license = CCPL
 	depends = geoip
-	source = http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
-	source = http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz
+	source = https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
+	source = https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz
 
 pkgname = geoip-asndata
 


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).